### PR TITLE
Prevent triggering builds on closed PRs [DI-248]

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -137,15 +137,13 @@ public class GhprbRootAction implements UnprotectedRootAction {
         try {
             GitHub gh = GitHub.connectAnonymously();
 
-            if (StringUtils.equalsIgnoreCase("issue_comment", event)) {
+            if (state == GHIssueState.CLOSED) {
+                LOGGER.log(Level.INFO, "Skip ''{0}'' event on closed PR", event);
+                return;
+            } else if (StringUtils.equalsIgnoreCase("issue_comment", event)) {
 
                 comment = getIssueComment(payload, gh);
                 GHIssueState state = comment.getIssue().getState();
-
-                if (state == GHIssueState.CLOSED) {
-                    LOGGER.log(Level.INFO, "Skip comment on closed PR");
-                    return;
-                }
 
                 if (!comment.getIssue().isPullRequest()) {
                     LOGGER.log(Level.INFO, "Skip comment on Issue");

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -137,13 +137,15 @@ public class GhprbRootAction implements UnprotectedRootAction {
         try {
             GitHub gh = GitHub.connectAnonymously();
 
-            if (state == GHIssueState.CLOSED) {
-                LOGGER.log(Level.INFO, "Skip ''{0}'' event on closed PR", event);
-                return;
-            } else if (StringUtils.equalsIgnoreCase("issue_comment", event)) {
+            if (StringUtils.equalsIgnoreCase("issue_comment", event)) {
 
                 comment = getIssueComment(payload, gh);
                 GHIssueState state = comment.getIssue().getState();
+
+                if (state == GHIssueState.CLOSED) {
+                    LOGGER.log(Level.INFO, "Skip comment on closed PR");
+                    return;
+                }
 
                 if (!comment.getIssue().isPullRequest()) {
                     LOGGER.log(Level.INFO, "Skip comment on Issue");
@@ -159,6 +161,13 @@ public class GhprbRootAction implements UnprotectedRootAction {
             } else if (StringUtils.equalsIgnoreCase("pull_request", event)) {
 
                 pr = getPullRequest(payload, gh);
+                GHIssueState state = pr.getPullRequest().getState();
+
+                if (state == GHIssueState.CLOSED) {
+                    LOGGER.log(Level.INFO, "Skip ''{0}'' event on closed PR", event);
+                    return;
+                }
+
                 repoName = pr.getRepository().getFullName();
 
                 LOGGER.log(Level.INFO, "Checking PR #{1} for {0}", new Object[] {repoName, pr.getNumber()});


### PR DESCRIPTION
Skips all kind of event triggers for closed PRs, rather than just for comments as per https://github.com/jenkinsci/ghprb-plugin/pull/54.

I've not added a test to cover this, as there's no existing test coverage for `pull_request` events in `org.jenkinsci.plugins.ghprb.GhprbRootActionTest`, nor is there any example payloads in `org.jenkinsci.plugins.ghprb.GhprbTestUtil`.

Fixes: https://github.com/jenkinsci/ghprb-plugin/issues/865, [DI-248](https://hazelcast.atlassian.net/browse/DI-248)

Post-merge actions:
- [x] Deploy in Jenkins
- [x] Test
- [x] Raise upstream PR

[DI-248]: https://hazelcast.atlassian.net/browse/DI-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ