### PR TITLE
Bump `nexus-staging-maven-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <version>1.7.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
The [release job has failed](https://github.com/hazelcast/jenkinsci-plugin-ghprb/actions/runs/10697984334/job/29656358585) with a nexus-related error:
> SEVERE: A message body reader for Java class com.sonatype.nexus.staging.api.dto.StagingProfileRepositoryDTO, and Java type class com.sonatype.nexus.staging.api.dto.StagingProfileRepositoryDTO, and MIME media type text/html was not found

It therefore seems sensible to bump the version and retry.