### PR TITLE
Migrate jenkinsci-plugin-ghprb to new Maven Central [DI-631]

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -33,18 +33,18 @@ jobs:
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
         cache: 'maven'
 
-
     - name: Do the Deployment and related stuff
       run: |
-        mvn versions:set -B -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
+        mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
         git commit -am "Release ${{ github.event.inputs.release-version }}"
         git tag v${{ github.event.inputs.release-version }}
-        mvn clean install -B
-        mvn deploy -B -Prelease -DskipTests
-        mvn versions:set -B -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
+        mvn clean install
+        mvn deploy --activate-profiles release -DskipTests
+        mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
         git commit -am "Next version is ${{ github.event.inputs.next-snapshot-version }}"
         git push origin v${{ github.event.inputs.release-version }} hazelcast-patches
       env:
         MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        MAVEN_ARGS: --batch-mode --no-transfer-progress

--- a/.github/workflows/push-snapshots.yaml
+++ b/.github/workflows/push-snapshots.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - hazelcast-patches
+  workflow_dispatch:
 
 jobs:
   release:
@@ -29,11 +30,12 @@ jobs:
 
       - name: Publish to Apache Maven Central
         run: |
-          PROJECT_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          PROJECT_VERSION=$(mvn --quiet -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
           if [[ "$PROJECT_VERSION" == *-SNAPSHOT ]]; then
-            mvn --batch-mode -Prelease deploy
+            mvn --activate-profiles release deploy
           fi
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          MAVEN_ARGS: --batch-mode --no-transfer-progress

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,9 @@
 
     <licenses>
         <license>
-            <name>The Apache License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <name>MIT license</name>
+            <url>https://github.com/hazelcast/jenkinsci-plugin-ghprb/blob/hazelcast-patches/LICENSE</url>
+            <distribution>repo</distribution>
         </license>
     </licenses>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,13 @@
 
     <url>https://github.com/hazelcast/jenkinsci-plugin-ghprb</url>
 
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
     <developers>
         <developer>
             <id>hazelcast-team</id>
@@ -201,17 +208,6 @@
         </plugins>
     </build>
 
-    <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
-
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
@@ -240,14 +236,21 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <!-- server id comes from settings.xml -->
+                            <publishingServerId>ossrh</publishingServerId>
+                            <!--
+                            wait until the artifacts are actually published automatically using 'autoPublish'.
+                            the default is `validated` which would then require manual publishing
+                            -->
+                            <waitUntil>published</waitUntil>
+                            <autoPublish>true</autoPublish>
+                            <checksums>required</checksums>
+                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
### Changes 

1. In similar vein as https://github.com/hazelcast/attribution-maven-plugin/pull/143
2. Added missing `<licenses>`  in pom.xml
3. This is OSS only project so plugin deploys SNAPSHOT and release artifacts
4. note: parent branch is [hazelcast-patches](https://github.com/hazelcast/jenkinsci-plugin-ghprb/tree/hazelcast-patches)

### Testing
#### Snapshot

Version: `5.2.0-SNAPSHOT`

- Ran [build](https://github.com/hazelcast/jenkinsci-plugin-ghprb/actions/runs/18101263034) on my branch
- Deployed successfully. Example [maven-metadata.xml](https://central.sonatype.com/repository/maven-snapshots/com/hazelcast/jenkins/plugins/ghprb/5.2.0-SNAPSHOT/maven-metadata.xml)

#### Release

Version: `1.1.1`

Made temp changes [diff](https://github.com/hazelcast/jenkinsci-plugin-ghprb/compare/jenkinsci-plugin-ghprb-new-portal...TEST-jenkinsci-plugin-ghprb-new-portal)

1. Ran build [successfully](https://github.com/hazelcast/jenkinsci-plugin-ghprb/actions/runs/18101019610)
2. Validated deployment available for publishing [here](https://central.sonatype.com/publishing/deployments)
3. <img width="802" height="319" alt="image" src="https://github.com/user-attachments/assets/789422d9-301f-49d6-bace-adf21552f412" />

### Post tasks

- [x] Remove staged deployment
- [x] Remove temp branches

Fixes [DI-631](https://hazelcast.atlassian.net/browse/DI-631)

[DI-631]: https://hazelcast.atlassian.net/browse/DI-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ